### PR TITLE
Fix: json.loads 无法在3.6以下版本运行

### DIFF
--- a/common/apiutil.py
+++ b/common/apiutil.py
@@ -38,7 +38,7 @@ class AiPlat(object):
         req = urllib.request.Request(self.url, self.url_data)
         try:
             rsp = urllib.request.urlopen(req)
-            str_rsp = rsp.read()
+            str_rsp = rsp.read().decode('utf-8')
             dict_rsp = json.loads(str_rsp)
             return dict_rsp
         except Exception as e:


### PR DESCRIPTION
fix: #49 #30 
json.loads 在 python3.6 以下无法接收 byte 类型