### PR TITLE
fix(sec): upgrade scikit-learn to 0.24.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ xlrd==1.1.0
 pandas==0.22.0
 numpy==1.14.1
 Pillow==5.1.0
-scikit-learn==0.19.1
+scikit-learn==0.24.2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in scikit-learn 0.19.1
- [MPS-2022-15126](https://www.oscs1024.com/hd/MPS-2022-15126)


### What did I do？
Upgrade scikit-learn from 0.19.1 to 0.24.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS